### PR TITLE
fix: show comparison

### DIFF
--- a/lib/components/dialogs/app_version_custom_dialog.dart
+++ b/lib/components/dialogs/app_version_custom_dialog.dart
@@ -41,7 +41,7 @@ class AppVersionCustomDialog extends AccessoryCheckUpdate {
   Future<bool> show() async {
     final upd = await checkUpdated();
 
-    if ((showWeb ?? true) && upd) {
+    if (upd && (showWeb ?? true)) {
       showDialog<void>(
         context: context,
         barrierDismissible: barrierDismissible,

--- a/lib/components/dialogs/app_version_overlay_dialog.dart
+++ b/lib/components/dialogs/app_version_overlay_dialog.dart
@@ -43,9 +43,10 @@ class AppVersionOverlayDialog extends AccessoryCheckUpdate {
   /// - `false` otherwise.
   Future<bool> show() async {
     final upd = await checkUpdated();
-    if (showWeb ?? true && upd) {
+    if (upd && (showWeb ?? true)) {
       overlayEntry = OverlayEntry(
-        builder: (BuildContext context) => overlayBuilder(context, overlayEntry),
+        builder: (BuildContext context) =>
+            overlayBuilder(context, overlayEntry),
       );
 
       Overlay.of(context).insert(overlayEntry);


### PR DESCRIPTION
When two version numbers are identical,
the primary comparison result (upd) is prioritized, followed by whether or not to display (showWeb).
For example:

```dart
var newVer='1.0.0.1', var  oldVer='1.0.0.1'; var upd = false;

var display = (upd && (showWeb ?? true)); // display == false;
```